### PR TITLE
Rewrite SECURITY.md to mirror the updated security-report policy (no fixed bounty amounts)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,10 +12,10 @@ You can find the latest version of this this document at
 
 | Severity     | Reward    |
 | ------------ | ----------|
-| Critical     | $800      |
-| High         | $400      |
-| Medium       | $200      |
-| Low          | $100      |
+| Critical     | $400      |
+| High         | $200      |
+| Medium       | $100      |
+| Low          | -         |
 | Informative  | -         |
 
 The severity is based on the [CVSS (Common Vulnerability Scoring System)](https://www.first.org/cvss/calculator/3.0). 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,87 +1,119 @@
 ## Reporting a Vulnerability
 
-WP Staging, being a major backup plugin in the WordPress environment, 
-prioritizes its security immensely. Acknowledging that complete coverage of all 
-security aspects is challenging, we encourage our users and the security 
-community to directly communicate any security-related discoveries to us. 
-This article will guide you on submitting your reports, 
-the applicable guidelines, and the rewards you can expect for your contributions.
+WP STAGING, as one of the leading backup and staging plugins in the WordPress
+ecosystem, takes security very seriously. No software project can cover every
+security aspect completely, so we encourage our users and the security
+community to report security findings directly to us. This document explains
+how to submit a report, which guidelines apply, and how we evaluate and reward
+contributions.
 
-You can find the latest version of this this document at
+You can find the latest version of this policy at
 [https://wp-staging.com/submit-a-security-report-for-wp-staging/](https://wp-staging.com/submit-a-security-report-for-wp-staging/)
 
-| Severity     | Reward    |
-| ------------ | ----------|
-| Critical     | $400      |
-| High         | $200      |
-| Medium       | $100      |
-| Low          | -         |
-| Informative  | -         |
+## Recognition & Rewards
 
-The severity is based on the [CVSS (Common Vulnerability Scoring System)](https://www.first.org/cvss/calculator/3.0). 
-When submitting your security report, make sure to include a calculation of the CVSS. 
-The reward table provides general guidelines, and all final decisions are at the discretion of WP Staging.
+We offer monetary rewards for eligible vulnerability reports through our bug
+bounty program. Each report is evaluated individually based on its technical
+severity, exploitability, attack prerequisites, affected configurations,
+report quality, completeness of the submission, and overall security impact.
 
-## The premises / scope of this program
+While CVSS is an important input to our evaluation, it is not the sole
+determining factor. Final severity classifications and reward decisions are
+made solely at the discretion of WP STAGING.
 
-The scope of this reward program is the latest version of our plugins. Specifically:
+## How we assess severity
 
-- WP Staging free version
-- WP Staging Pro version
+Severity is primarily assessed using the
+[Common Vulnerability Scoring System (CVSS)](https://www.first.org/cvss/calculator/3.0),
+together with our own review of exploitability, attack prerequisites, affected
+configurations, real-world impact, and other relevant technical factors. CVSS
+gives us a common language for classifying vulnerabilities, but it serves as
+guidance rather than as an automatic scoring formula.
 
-The scope of this program does not extend to any other products or services related to WP Staging, 
-including the WP Staging website and customer portal. However, if you do come across a significant 
-security issue within these areas, we strongly encourage you to inform us.
+Every vulnerability is unique. Two reports with similar CVSS scores may
+receive different severity classifications or rewards depending on
+exploitability, affected environments, report quality, and overall security
+impact. Our internal review process, including the exact scoring and weighting
+we apply, is not disclosed.
+
+## Scope of this program
+
+This reward program covers the latest release of our plugins:
+
+- The free WP STAGING plugin
+- WP Staging Pro
+
+Other products and services related to WP STAGING, including the website and
+the customer portal, are not part of this program. If you discover a
+significant security issue in these areas anyway, we still want to hear about
+it.
 
 ## Issues that are out of scope
 
-- WP Staging version number disclosure.
-- Comma Separated Values (CSV) injection without demonstrating a vulnerability.
-- Missing best practices in SSL/TLS configuration.
-- Content spoofing and text injection issues without showing an attack vector/without being able to modify HTML/CSS.
-- Theoretical vulnerabilities where you can’t demonstrate a significant security impact with a Proof of Concept.
-- Users with administrator or editor privileges can post arbitrary JavaScript.
-- Output from automated scans – please manually verify issues and include a valid Proof of Concept.
-- Not following security best practices – without a working Proof of Concept.
+- Disclosure of the WP STAGING version number.
+- CSV (Comma Separated Values) injection without demonstrating a vulnerability.
+- Missing best practices in the SSL/TLS configuration.
+- Content spoofing and text injection issues without an attack vector, or
+  without the ability to modify HTML or CSS.
+- Theoretical vulnerabilities without a proof of concept that demonstrates a
+  significant security impact.
+- The fact that users with administrator or editor privileges can post
+  arbitrary JavaScript.
+- Raw output from automated scanners. Please verify issues manually and
+  include a working proof of concept.
+- Deviations from security best practices without a working proof of concept.
 
 ## How to get a copy of our plugins for testing
 
-You can get WP Staging free version from wordpress.org at
-https://wordpress.org/plugins/wp-staging/
-
-If you want to get WP Staging Pro for security testing, please contact us at support [at] wp-staging.com, providing a plan what you are going to do.
+You can download the free WP STAGING plugin from wordpress.org at
+[https://wordpress.org/plugins/wp-staging/](https://wordpress.org/plugins/wp-staging/).
+If you would like to test WP Staging Pro, contact us at
+support [at] wp-staging.com and briefly describe what you plan to test.
 
 ## Conditions and rules
 
-Ensure your reports are detailed and include step-by-step procedures that can be easily followed. Reports that lack sufficient detail for issue reproduction will not qualify for a reward. 
+- Write detailed reports and include step-by-step instructions that we can
+  follow to reproduce the issue. Reports that cannot be reproduced from the
+  information provided do not qualify for a reward.
+- Focus each report on a single vulnerability, unless demonstrating the impact
+  requires chaining several vulnerabilities.
+- For duplicate submissions, only the first reproducible report we receive is
+  eligible for a reward. Issues that are already known to us are treated the
+  same way.
+- If multiple vulnerabilities stem from the same root cause, we may treat them
+  as a single issue for reward purposes.
+- When your testing could affect systems, services, or data you do not own,
+  protect privacy, data integrity, and service availability at all times. Only
+  interact with accounts you own or accounts whose holders have given you
+  explicit consent.
 
-Each report should focus on a single vulnerability, unless demonstrating the impact requires chaining multiple vulnerabilities. 
+## Responsible disclosure
 
-In cases of duplicate submissions, a reward will be given only to the first received report that can be fully reproduced. 
+Please keep your findings confidential. Do not publish or discuss a
+vulnerability, even a resolved one, until a fix is available to our users and
+we have agreed on disclosure with you. Coordinated disclosure protects the
+many websites that rely on WP STAGING while we work on a fix.
 
-If multiple vulnerabilities stem from a single root cause, they may be considered as one for the purposes of reward eligibility. 
+## Submit your report
 
-When conducting tests that might affect systems or services not owned by you, the tester, it is crucial to prioritize privacy, data integrity, and service continuity. Avoid any actions that might compromise these aspects. Interactions should be limited to accounts you own or those where you have received explicit consent from the account holder.
+If you have identified a security issue that matches the guidelines and scope
+of this program, send your findings to support [at] wp-staging.com and include
+the following:
 
-## Disclosure Policy
+- The affected plugin and the version(s) you tested.
+- Your own CVSS assessment with brief reasoning, using the
+  [CVSS calculator](https://www.first.org/cvss/calculator/3.0). Including your
+  calculation helps us evaluate your report more efficiently, but it does not
+  automatically determine the final severity classification or reward.
+- An explanation of the potential impact of the issue.
+- A step-by-step walkthrough to reproduce the issue, with a proof of concept
+  where appropriate.
+- The email address associated with your WP STAGING account.
 
-Please do not discuss any vulnerabilities (even resolved ones) without express consent.
+## After your report
 
-## Submit Your report
-
-If you identify a security concern that complies with the guidelines and scope of this project, kindly forward your findings to us at support @ wp-staging.com. In your email, please ensure you cover the following points:
-
-- Your assessment of the CVSS score, utilizing the [provided calculator](https://www.first.org/cvss/calculator/3.0).
-- An explanation of the potential impact of the problem.
-- A comprehensive walkthrough detailing the steps to replicate the issue.
-- The email address associated with your WP Staging account that you used for registration.
-
-## After Your Report 
-
-Our team is committed to addressing security reports with the utmost diligence and will aim to achieve the following response goals:
-
-- Initial response time (after receiving the report) – within 3 business days
-- Time to assess and categorize the report (from the time of submission) – within 10 business days
-- Time to determine and issue a bounty (following the assessment phase) – within 10 business days
-
-Throughout this process, we will ensure that you are regularly updated on our progress.
+We aim to acknowledge new reports within a few business days and to review
+every submission promptly. We will keep you informed while we validate the
+issue, work on a fix, and decide on a reward. Response times may vary
+depending on the complexity of the issue, and reward decisions are made once
+the full impact and the fix are clear.


### PR DESCRIPTION
## What

Rewrites `SECURITY.md` (shown on the GitHub Security tab) to mirror the updated canonical policy page: https://wp-staging.com/submit-a-security-report-for-wp-staging/

- Removes the fixed bounty table entirely. Rewards are now described as individually evaluated per report.
- CVSS is presented as an important input, not an automatic scoring formula; final severity and reward decisions are at WP STAGING's discretion.
- Adds a transparency note: similar CVSS scores can lead to different classifications/rewards; the internal scoring process is not disclosed.
- Softens timeline wording (no fixed business-day guarantees).
- Strengthens responsible disclosure and adds affected version(s) to the required report contents.
- Applies brand naming (WP STAGING / WP Staging Pro).

## Why

The published fixed amounts attracted a flood of low-quality AI-generated reports and created conflicting numbers across the site (three different tables existed). The policy page was rewritten on 2026-07-10 (EN + DE); this keeps GitHub consistent with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)