### PR TITLE
Add machine-generated report rule to SECURITY.md conditions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,6 +75,8 @@ support [at] wp-staging.com and briefly describe what you plan to test.
 - Write detailed reports and include step-by-step instructions that we can
   follow to reproduce the issue. Reports that cannot be reproduced from the
   information provided do not qualify for a reward.
+- Reports that appear machine-generated and were not manually verified will
+  be closed without a reward.
 - Focus each report on a single vulnerability, unless demonstrating the impact
   requires chaining several vulnerabilities.
 - For duplicate submissions, only the first reproducible report we receive is


### PR DESCRIPTION
One bullet under **Conditions and rules**: reports that appear machine-generated and were not manually verified are closed without a reward.

This was pushed to the #338 branch 16 seconds after the squash-merge, so it missed the train. The pro repo (wp-staging-pro#5366) and the live policy page already have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)